### PR TITLE
Handle list collections decryption errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ coverage
 .nyc_output
 
 # env files
+.envrc
 .envrc.*
 !.envrc.example

--- a/packages/stashjs/CHANGELOG.md
+++ b/packages/stashjs/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Fixed
+
+- Filter out incompatible collections rather than returning an error when listing collections.
+  This is a short-term fix for incompatibilities in ciphertext formats between StashJS and StashRB.
+
 ## [0.5.0]
 
 ## Added

--- a/packages/stashjs/src/result.ts
+++ b/packages/stashjs/src/result.ts
@@ -123,6 +123,17 @@ export function gather<V, E>(results: Array<Result<V, E>>): Result<Array<V>, E> 
   return results.reduce<Result<Array<V>, E>>(concat, Ok<Array<V>>([]))
 }
 
+/**
+ * Removes errors from an Array<Result<V, E>>.
+ *
+ * @param results the array of results to remove errors from
+ *
+ * @returns Array<Result<V, E>>
+ */
+export function removeErrors<V, E>(results: Array<Result<V, E>>): Array<Result<V, E>> {
+  return results.filter(isOk)
+}
+
 export async function gatherAsync<V, E>(asyncResults: Array<AsyncResult<V, E>>): AsyncResult<Array<V>, E> {
   const results = await Promise.all(asyncResults)
   return results.reduce<Result<Array<V>, E>>(concat, Ok<Array<V>>([]))

--- a/packages/stashjs/src/stash-internal.ts
+++ b/packages/stashjs/src/stash-internal.ts
@@ -23,6 +23,7 @@ import {
   toAsync,
   gatherTuple2,
   convertAsyncErrorsTo,
+  removeErrors,
 } from "./result"
 import {
   CollectionCreationFailure,
@@ -307,8 +308,16 @@ export class StashInternal {
     return await sequence(
       _ => convertAsyncErrorsTo(DecryptionFailure, this.sourceDataCipherSuiteMemo.freshValue()),
       async cipher =>
-        Ok(await Promise.all(res.collections!.map(info => cipher.decrypt<CollectionMetadata>(info!.metadata!)))),
-      decryptions => toAsync(gather(decryptions))
+        Ok(await Promise.all(res.collections!.map(async info => {
+          const result = await cipher.decrypt<CollectionMetadata>(info!.metadata!)
+
+          if (!result.ok) {
+            logger.warn("Failed to decrypt collection. This collection will be filtered from the collection list.", { error: result.error })
+          }
+
+          return result
+        }))),
+      decryptions => toAsync(gather(removeErrors(decryptions)))
     )(Unit)
   }
 }


### PR DESCRIPTION
This change prevents listing collections from returning errors by filtering out collections that fail to decrypt. If `CS_DEBUG=yes` a warning will be logged that the collection was filtered out. Otherwise, the collection is silently dropped from results.

This is a short-term fix for incompatibilities in ciphertext formats between StashJS and StashRB. Filtering out incompatible collections means that StashJS will only list collections that it can work with.

The intent here is to implement a reasonable short-term solution without changing other behaviour in StashJS. Note that this change still won't allow for deleting collections created from StashRB, but StashJS should be able to list collections that it created and clean up after itself now (even if there are collections created by StashRB in the same workspace).