### PR TITLE
Add ID, name, and ref to describe-collection output in stash-cli

### DIFF
--- a/packages/stash-cli/CHANGELOG.md
+++ b/packages/stash-cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Added
+
+- Added ID, name, and ref to describe-collection output. This a breaking change for the output format when the `--json` flag is provided.
+
 ## Changed
 
 - Upgrade axios to 0.27.2

--- a/packages/stash-cli/src/commands/describe-collection.ts
+++ b/packages/stash-cli/src/commands/describe-collection.ts
@@ -45,14 +45,32 @@ const command: GluegunCommand = {
       })
 
       if (parameters.options.json) {
-        print.info(JSON.stringify(mappings, null, 2))
+        const json = {
+          id: collection.id,
+          name: collection.name,
+          ref: collection.ref,
+          mappings,
+        }
+        print.info(JSON.stringify(json, null, 2))
       } else {
+        print.highlight(" Identifiers:")
+        print.table(
+          [
+            ["ID", collection.id],
+            ["Name", collection.name],
+            ["Ref (hex encoded)", collection.ref],
+          ],
+          { format: "lean" }
+        )
+
         const tbl = [["Index Name", "Index Type", "Field(s)", "Query Operators"]]
 
         for (const k in mappings) {
           tbl.push([k, mappings[k].indexType, mappings[k].fields, mappings[k].operators])
         }
 
+        print.newline()
+        print.highlight(" Indexes:")
         print.table(tbl, { format: "lean" })
       }
     } catch (error) {


### PR DESCRIPTION
This PR adds ID, name and ref to the output of `stash describe-collection <name>`.

Example output:
<img width="721" alt="Screen Shot 2022-08-11 at 9 25 17 am" src="https://user-images.githubusercontent.com/7672425/184041446-08486e20-8fd3-4ac9-9888-72237ce8c2ab.png">

With the `--json` flag:
```
❯ ./bin/stash describe-collection movies --profile dev-local --json
{
  "id": "df1a2232-b5a0-4d9d-9a82-532277f493d7",
  "name": "movies",
  "ref": "6a5b5eb7a37ce3848a13d11f3b2223b2054129fbaf4a97adac256b700747c08f",
  "mappings": {
    "exactTitle": {
      "indexType": "exact",
      "fields": "title",
      "operators": "="
    },
    "runningTime": {
      "indexType": "range",
      "fields": "runningTime",
      "operators": "<, <=, =, >= >"
    },
    "year": {
      "indexType": "range",
      "fields": "year",
      "operators": "<, <=, =, >= >"
    },
    "title": {
      "indexType": "match",
      "fields": "title",
      "operators": "=~"
    }
  }
}
```