### PR TITLE
Feat: inherit strictest base tsconfig for node 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "lint:fix": "prettier . --write"
   },
   "devDependencies": {
-    "@tsconfig/node16": "^1.0.3",
+    "@tsconfig/node16-strictest": "^1.0.3",
     "prettier": "2.6.2",
     "typescript": "^4.7.4"
   }

--- a/packages/stash-cli/tsconfig.json
+++ b/packages/stash-cli/tsconfig.json
@@ -8,6 +8,7 @@
     "tsBuildInfoFile": "./build/tsconfig.tsbuildinfo",
 
     // Relaxed rules to allow package to build. FIXME: remove these and fix in code
+    "exactOptionalPropertyTypes": false,
     "noImplicitAny": false,
     "noPropertyAccessFromIndexSignature": false
   },

--- a/packages/stash-cli/tsconfig.json
+++ b/packages/stash-cli/tsconfig.json
@@ -9,6 +9,7 @@
 
     // Relaxed rules to allow package to build. FIXME: remove these and fix in code
     "exactOptionalPropertyTypes": false,
+    "importsNotUsedAsValues": "remove",
     "noImplicitAny": false,
     "noPropertyAccessFromIndexSignature": false
   },

--- a/packages/stashjs-grpc/tsconfig.json
+++ b/packages/stashjs-grpc/tsconfig.json
@@ -5,7 +5,7 @@
 
     // Relaxed rules to allow package to build. FIXME: remove these and fix in code
     "exactOptionalPropertyTypes": false,
-    "importsNotUsedAsValues": "preserve",
+    "importsNotUsedAsValues": "remove",
     "noUnusedLocals": false
   },
 

--- a/packages/stashjs-grpc/tsconfig.json
+++ b/packages/stashjs-grpc/tsconfig.json
@@ -2,11 +2,11 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "noUnusedLocals": false,
 
     // Relaxed rules to allow package to build. FIXME: remove these and fix in code
     "exactOptionalPropertyTypes": false,
-    "importsNotUsedAsValues": "preserve"
+    "importsNotUsedAsValues": "preserve",
+    "noUnusedLocals": false
   },
 
   "include": ["generated/**/*", "index.ts"],

--- a/packages/stashjs-grpc/tsconfig.json
+++ b/packages/stashjs-grpc/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "noUnusedLocals": false
+    "noUnusedLocals": false,
+
+    // Relaxed rules to allow package to build. FIXME: remove these and fix in code
+    "exactOptionalPropertyTypes": false,
+    "importsNotUsedAsValues": "preserve"
   },
 
   "include": ["generated/**/*", "index.ts"],

--- a/packages/stashjs-typeorm/tsconfig.json
+++ b/packages/stashjs-typeorm/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
+
+    // Add support for decorators
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
 

--- a/packages/stashjs-typeorm/tsconfig.json
+++ b/packages/stashjs-typeorm/tsconfig.json
@@ -1,13 +1,12 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["es5", "es6", "es2019"],
-    "target": "es5",
     "outDir": "./dist",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
 
     // Relaxed rules to allow package to build. FIXME: remove these and fix in code
+    "exactOptionalPropertyTypes": false,
     "noImplicitAny": false,
     "noImplicitReturns": false,
     "noImplicitThis": false,

--- a/packages/stashjs-typeorm/tsconfig.json
+++ b/packages/stashjs-typeorm/tsconfig.json
@@ -9,6 +9,7 @@
 
     // Relaxed rules to allow package to build. FIXME: remove these and fix in code
     "exactOptionalPropertyTypes": false,
+    "importsNotUsedAsValues": "remove",
     "noImplicitAny": false,
     "noImplicitReturns": false,
     "noImplicitThis": false,

--- a/packages/stashjs/tsconfig.json
+++ b/packages/stashjs/tsconfig.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
+
+    // Relaxed rules to allow package to build. FIXME: remove these and fix in code
+    "exactOptionalPropertyTypes": false,
+    "importsNotUsedAsValues": "preserve"
   },
   "include": ["src/*", "src/**/*"],
   "exclude": ["dist", "node_modules", "./**/*.spec.ts", "./**/*.test.ts"]

--- a/packages/stashjs/tsconfig.json
+++ b/packages/stashjs/tsconfig.json
@@ -7,7 +7,7 @@
 
     // Relaxed rules to allow package to build. FIXME: remove these and fix in code
     "exactOptionalPropertyTypes": false,
-    "importsNotUsedAsValues": "preserve"
+    "importsNotUsedAsValues": "remove"
   },
   "include": ["src/*", "src/**/*"],
   "exclude": ["dist", "node_modules", "./**/*.spec.ts", "./**/*.test.ts"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,11 +4,11 @@ importers:
 
   .:
     specifiers:
-      '@tsconfig/node16': ^1.0.3
+      '@tsconfig/node16-strictest': ^1.0.3
       prettier: 2.6.2
       typescript: ^4.7.4
     devDependencies:
-      '@tsconfig/node16': 1.0.3
+      '@tsconfig/node16-strictest': 1.0.3
       prettier: 2.6.2
       typescript: 4.7.4
 
@@ -133,7 +133,7 @@ importers:
       '@aws-sdk/client-kms': 3.141.0
       '@aws-sdk/client-sts': 3.141.0
       '@cfworker/json-schema': 1.12.3
-      '@cipherstash/stash-rs': 0.3.0
+      '@cipherstash/stash-rs': link:../stash-rs
       '@cipherstash/stashjs-grpc': link:../stashjs-grpc
       '@grpc/grpc-js': 1.6.8
       '@grpc/proto-loader': 0.6.13
@@ -2197,14 +2197,6 @@ packages:
     resolution: {integrity: sha512-L27wX0PkCGKadJeNqfpiLrXSfbLoC7xTmnF9OImA3Zr6Vtd9BeZGEOa5SKEzeS+ukkFUtN98Pz77vdEfobeTFg==}
     dev: false
 
-  /@cipherstash/stash-rs/0.3.0:
-    resolution: {integrity: sha512-8p+y6FJ8cvLGjGdtCPRfgpg53r3FPz087TJR2nAWZiRTA2duwi40WU+ZijD1mf+FXXxLjQqEkQrh7FhYBiD61w==}
-    requiresBuild: true
-    dependencies:
-      cargo-cp-artifact: 0.1.6
-      cbor: 8.1.0
-    dev: false
-
   /@cnakazawa/watch/1.0.4:
     resolution: {integrity: sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==}
     engines: {node: '>=0.1.95'}
@@ -2837,6 +2829,10 @@ packages:
 
   /@tsconfig/node14/1.0.3:
     resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    dev: true
+
+  /@tsconfig/node16-strictest/1.0.3:
+    resolution: {integrity: sha512-sY7TxE3BzAdsCuKqGWOTtAoPe4tPD0xlPWfjinJvrBvCulyALVSwvIoo7WMcX8O/WyMFzn9rQObA43mAogQ8MQ==}
     dev: true
 
   /@tsconfig/node16/1.0.3:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json",
-  // See: https://github.com/tsconfig/bases/blob/main/bases/node16.json
+  "extends": "@tsconfig/node16-strictest/tsconfig.json",
+  // See: https://github.com/tsconfig/bases/blob/main/bases/node16-strictest.combined.json
   // Inherited config:
   // {
-  //   "display": "Node 16",
+  //   "display": "Node 16 + Strictest",
   //   "compilerOptions": {
   //     "lib": ["es2021"],
   //     "module": "commonjs",
@@ -11,7 +11,20 @@
   //     "strict": true,
   //     "esModuleInterop": true,
   //     "skipLibCheck": true,
-  //     "forceConsistentCasingInFileNames": true
+  //     "forceConsistentCasingInFileNames": true,
+  //     "moduleResolution": "node",
+  //     "allowUnusedLabels": false,
+  //     "allowUnreachableCode": false,
+  //     "exactOptionalPropertyTypes": true,
+  //     "noFallthroughCasesInSwitch": true,
+  //     "noImplicitOverride": true,
+  //     "noImplicitReturns": true,
+  //     "noPropertyAccessFromIndexSignature": true,
+  //     "noUncheckedIndexedAccess": true,
+  //     "noUnusedLocals": true,
+  //     "noUnusedParameters": true,
+  //     "importsNotUsedAsValues": "error",
+  //     "checkJs": true
   //   }
   // }
 
@@ -20,42 +33,27 @@
   "compilerOptions": {
     "composite": true,
     "incremental": true,
-    "allowJs": false,
-    "allowUnreachableCode": false,
-    "allowUnusedLabels": false,
     "alwaysStrict": true,
-    "checkJs": false,
     "declaration": true,
     "downlevelIteration": false,
     "emitDecoratorMetadata": false,
-    "esModuleInterop": true,
     "experimentalDecorators": false,
     "importHelpers": false,
     "sourceMap": true,
     "inlineSourceMap": false,
     "inlineSources": false,
-    "module": "CommonJS",
-    "moduleResolution": "Node",
     "noErrorTruncation": true,
-    "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
-    "noImplicitReturns": true,
     "noImplicitThis": true,
     "noLib": false,
-    "noPropertyAccessFromIndexSignature": true,
     "noStrictGenericChecks": false,
-    "noUncheckedIndexedAccess": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "preserveConstEnums": false,
     "removeComments": false,
-    "skipLibCheck": true,
-    "strict": true,
     "strictBindCallApply": true,
     "strictFunctionTypes": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
-    "target": "ES2020",
+    "importsNotUsedAsValues": "preserve",
     "useDefineForClassFields": false
   },
   "watchOptions": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,39 +28,19 @@
   //   }
   // }
 
-  // "exclude": ["./**/*.spec.ts", "./**/*.test.ts"],
-
   "compilerOptions": {
     "composite": true,
-    "incremental": true,
-    "alwaysStrict": true,
     "declaration": true,
-    "downlevelIteration": false,
-    "emitDecoratorMetadata": false,
-    "experimentalDecorators": false,
-    "importHelpers": false,
-    "sourceMap": true,
-    "inlineSourceMap": false,
-    "inlineSources": false,
+    "incremental": true,
     "noErrorTruncation": true,
-    "noImplicitAny": true,
-    "noImplicitThis": true,
-    "noLib": false,
-    "noStrictGenericChecks": false,
-    "preserveConstEnums": false,
-    "removeComments": false,
-    "strictBindCallApply": true,
-    "strictFunctionTypes": true,
-    "strictNullChecks": true,
-    "strictPropertyInitialization": true,
-    "importsNotUsedAsValues": "preserve",
+    "sourceMap": true,
     "useDefineForClassFields": false
   },
   "watchOptions": {
     "watchFile": "useFsEvents",
     "watchDirectory": "useFsEvents",
     "fallbackPolling": "dynamicPriority",
-    "excludeDirectories": ["node_modules", "build"]
+    "excludeDirectories": ["build", "dist", "node_modules"]
   },
   "references": [
     { "path": "./packages/stash-rs" },


### PR DESCRIPTION
From working with this repo typescript setup, I've noticed that the tsconfig options that we use are pretty strict. This gives an opportunity for us to just inherit the strictest base tsconfig for node 16 from upstream: [@tsconfig/node16-strictest/tsconfig.json](https://github.com/tsconfig/bases/blob/main/bases/node16-strictest.combined.json).

We can also remove any redundant configs that we added ourselves. This allows the `tsconfig.json` file to be much-much simpler. Redundant configs under the following conditions.
- already the default for typescript
- already enabled by default due to another options such as `strict`
- already exists in the `strictest` base config

Unfortunately, we have to relax some of the rules in our current packages by adding the overrides.