### PR TITLE
Bump StashJS and Stash CLI

### DIFF
--- a/packages/stash-cli/CHANGELOG.md
+++ b/packages/stash-cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.4.0]
+
 ## Added
 
 - Added ID, name, and ref to describe-collection output. This a breaking change for the output format when the `--json` flag is provided.

--- a/packages/stash-cli/package.json
+++ b/packages/stash-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cipherstash/stash-cli",
-  "version": "0.3.14",
+  "version": "0.4.0",
   "description": "CipherStash CLI",
   "types": "build/types/types.d.ts",
   "bin": {

--- a/packages/stashjs/CHANGELOG.md
+++ b/packages/stashjs/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.6.1]
+
 ## Fixed
 
 - Filter out incompatible collections rather than returning an error when listing collections.
   This is a short-term fix for incompatibilities in ciphertext formats between StashJS and StashRB.
+
+## [0.6.0]
 
 ## [0.5.0]
 

--- a/packages/stashjs/package.json
+++ b/packages/stashjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cipherstash/stashjs",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Datastore & Search API for CipherStash",
   "main": "dist/index.js",
   "typedocMain": "src/index.ts",


### PR DESCRIPTION
This PR bumps package versions:
* StashJS - 0.6.1. Bumped a patch version because of a bug fix.
* Stash CLI - 0.4.0. Bumped a minor version because of a new (breaking pre-stable release) feature.