### PR TITLE
Add cache steps for Cargo and pnpm to CI test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
   build-pnpm:
-    name: build + test (pnpm packages)
+    name: Build + Test
     runs-on: ubuntu-latest
 
     steps:
@@ -19,7 +19,7 @@ jobs:
 
     - uses: ./.github/actions/cache-asdf
 
-    - name: "Set up Cargo cache"
+    - name: Set up Cargo cache
       uses: actions/cache@v2
       with:
         path: |
@@ -43,15 +43,15 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pnpm-store-
 
-    - name: "Setup"
+    - name: Setup
       run: |
         ./build.sh setup
 
-    - name: "Build"
+    - name: Build
       run: |
         ./build.sh build
 
-    - name: "Test"
+    - name: Test
       run: |
         ./build.sh test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,38 @@ jobs:
 
     - uses: ./.github/actions/cache-asdf
 
+    - name: "Set up Cargo cache"
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+
+    - name: Get pnpm store directory
+      id: pnpm-cache
+      run: |
+        echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+
+    - name: Set up pnpm cache
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
+
     - name: "Setup"
       run: |
         ./build.sh setup
+
     - name: "Build"
       run: |
         ./build.sh build
+
     - name: "Test"
       run: |
         ./build.sh test


### PR DESCRIPTION
This PR adds cache steps for Cargo and pnpm to the CI test workflow.

This seems to shave a few min off for builds with cache hits because of fewer deps to download + only compiling stash-rs twice rather than three times.

Example of a build without the cache: https://github.com/cipherstash/cipherstash.js/runs/7800462761?check_suite_focus=true

Example of a build with the cache: https://github.com/cipherstash/cipherstash.js/runs/7800462761?check_suite_focus=true