### PR TITLE
Add export-schema command to stash-cli

### DIFF
--- a/packages/stash-cli/CHANGELOG.md
+++ b/packages/stash-cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Added
+
+- Added `export-schema` command for dumping schemas as JSON
+
 ## [0.4.0]
 
 ## Added

--- a/packages/stash-cli/src/commands/export-schema.ts
+++ b/packages/stash-cli/src/commands/export-schema.ts
@@ -1,0 +1,74 @@
+import { GluegunCommand } from "gluegun"
+import { Stash, describeError } from "@cipherstash/stashjs"
+import { Toolbox } from "gluegun/build/types/domain/toolbox"
+
+const command: GluegunCommand = {
+  name: "export-schema",
+
+  run: async (toolbox: Toolbox) => {
+    const { print, parameters } = toolbox
+
+    const profileName: string | undefined = parameters.options.profile
+
+    const profile = await Stash.loadProfile({ profileName }).catch(error => {
+      print.error(`Could not load profile. Reason: "${describeError(error)}"`)
+      process.exit(1)
+    })
+
+    function exitWithUsage(level: "info" | "error" = "info"): never {
+      print[level]("Usage: stash export-schema <collection-name> [--profile <profile>] [--help]")
+      print.newline()
+      print[level]("Export the schema for the given collection.")
+      print.newline()
+      print[level]("Example: stash export-schema movies")
+      process.exit(level === "info" ? 0 : 1)
+    }
+
+    if (parameters.options.help) {
+      exitWithUsage()
+    }
+
+    try {
+      const stash = await Stash.connect(profile)
+      const collectionName = parameters.first
+
+      if (collectionName === undefined) {
+        print.error("No collection name specified.")
+        print.newline()
+        exitWithUsage("error")
+      }
+
+      const collection = await stash.loadCollection(collectionName)
+      const indexes = {}
+
+      Object.entries(collection.schema.mappings).forEach(([indexName, mapping]) => {
+        const meta = {
+          $prpKey: [...collection.schema.meta[indexName]!.$prpKey],
+          $prfKey: [...collection.schema.meta[indexName]!.$prfKey],
+          $indexId: collection.schema.meta[indexName]!.$indexId,
+        }
+
+        // Remove fieldType that's denormalized onto the mappings for internal use by the client
+        const { fieldType, ...includedFields } = mapping
+
+        indexes[indexName] = {
+          ...includedFields,
+          ...meta,
+        }
+      })
+
+      const json = {
+        name: collection.name,
+        id: collection.id,
+        type: collection.schema.recordType,
+        indexes,
+      }
+
+      print.info(JSON.stringify(json, null, 2))
+    } catch (error) {
+      print.error(`Could not export schema. Reason: "${describeError(error)}"`)
+    }
+  },
+}
+
+export default command


### PR DESCRIPTION
This PR adds the `export-schema` command to Stash CLI.

This command dumps the current schema of the given collection to stdout as JSON. The output matches the shape of a JSON schema definition file, but also includes the collection name, the collection ID, and index meta (`$indexId`, `$prpKey` and `$prfKey`).

<details>
  <summary>Example output:</summary>

  ```sh
  $ ./bin/stash export-schema movies --profile dev-local
  {
    "name": "movies",
    "id": "df1a2232-b5a0-4d9d-9a82-532277f493d7",
    "type": {
      "title": "string",
      "runningTime": "float64",
      "year": "float64"
    },
    "indexes": {
      "exactTitle": {
        "kind": "exact",
        "field": "title",
        "$prpKey": [
          158,
          200,
          235,
          218,
          163,
          75,
          205,
          220,
          27,
          135,
          138,
          150,
          207,
          31,
          212,
          184
        ],
        "$prfKey": [
          157,
          205,
          119,
          122,
          150,
          83,
          37,
          125,
          33,
          29,
          137,
          8,
          64,
          155,
          193,
          179
        ],
        "$indexId": "31c361a2-21a5-420d-b42d-7a0fa27de8de"
      },
      "runningTime": {
        "kind": "range",
        "field": "runningTime",
        "$prpKey": [
          95,
          109,
          19,
          178,
          14,
          95,
          158,
          106,
          89,
          166,
          221,
          38,
          247,
          96,
          14,
          248
        ],
        "$prfKey": [
          150,
          20,
          43,
          199,
          162,
          50,
          216,
          116,
          203,
          215,
          66,
          245,
          34,
          36,
          151,
          74
        ],
        "$indexId": "fbd569b7-b76d-47e5-92ac-3c9f428d7981"
      },
      "year": {
        "kind": "range",
        "field": "year",
        "$prpKey": [
          0,
          30,
          196,
          214,
          120,
          202,
          128,
          142,
          126,
          192,
          82,
          171,
          27,
          205,
          153,
          136
        ],
        "$prfKey": [
          57,
          148,
          170,
          223,
          77,
          211,
          58,
          193,
          106,
          28,
          28,
          133,
          33,
          6,
          11,
          12
        ],
        "$indexId": "c3e904ac-ce58-4f19-a85c-f4dbad28554c"
      },
      "title": {
        "kind": "match",
        "fields": [
          "title"
        ],
        "tokenFilters": [
          {
            "kind": "downcase"
          },
          {
            "kind": "ngram",
            "tokenLength": 3
          }
        ],
        "tokenizer": {
          "kind": "standard"
        },
        "$prpKey": [
          204,
          233,
          194,
          97,
          152,
          99,
          29,
          205,
          32,
          247,
          167,
          84,
          102,
          13,
          20,
          44
        ],
        "$prfKey": [
          217,
          56,
          168,
          50,
          74,
          193,
          24,
          31,
          120,
          9,
          163,
          65,
          37,
          182,
          4,
          144
        ],
        "$indexId": "436e55a9-b10f-433c-91b2-eab87ca7d217"
      }
    }
  }
  ```
</details>