### PR TITLE
Fix weird chars in piped export-schema output

### DIFF
--- a/packages/stash-cli/CHANGELOG.md
+++ b/packages/stash-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.5.1]
+
+## Fixed
+
+- `export-schema` output including control chars
+
 ## [0.5.0]
 
 ## Added

--- a/packages/stash-cli/package.json
+++ b/packages/stash-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cipherstash/stash-cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "CipherStash CLI",
   "types": "build/types/types.d.ts",
   "bin": {

--- a/packages/stash-cli/src/commands/export-schema.ts
+++ b/packages/stash-cli/src/commands/export-schema.ts
@@ -64,7 +64,8 @@ const command: GluegunCommand = {
         indexes,
       }
 
-      print.info(JSON.stringify(json, null, 2))
+      // Console log instead of using `print.info` here so output can be redirected to a file.
+      console.log(JSON.stringify(json, null, 2))
     } catch (error) {
       print.error(`Could not export schema. Reason: "${describeError(error)}"`)
     }


### PR DESCRIPTION
When piping to a file the output of export-schema contained a couple control chars. This was because of print.info adding some colours or something.
