### PR TITLE
Rename Test PR workflow to Build and Test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test PR — pnpm packages
+name: Build and Test
 on:
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
This change renames the CI test workflow to be less confusing.

The Build and Test workflow runs for both PRs and pushes to main.