### PR TITLE
Add ref to export schema

### DIFF
--- a/packages/stash-cli/src/commands/export-schema.ts
+++ b/packages/stash-cli/src/commands/export-schema.ts
@@ -61,6 +61,7 @@ const command: GluegunCommand = {
         name: collection.name,
         id: collection.id,
         type: collection.schema.recordType,
+        ref:  [...Buffer.from(collection.ref, 'hex')],
         indexes,
       }
 


### PR DESCRIPTION
This wasn't originally included because it wasn't strictly needed.

However, since we now want the `Colletion` struct in the Rust client to be created from an annotated schema it should probably be included.
