### PR TITLE
Bump stash-cli to 0.5.2

### DIFF
--- a/packages/stash-cli/CHANGELOG.md
+++ b/packages/stash-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.5.2]
+
+## Fixed
+
+- Installing longer warns about severe vulnerability
+
 ## [0.5.1]
 
 ## Fixed

--- a/packages/stash-cli/CHANGELOG.md
+++ b/packages/stash-cli/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
-- Installing longer warns about severe vulnerability
+- Installing no longer warns about severe vulnerability
 
 ## [0.5.1]
 

--- a/packages/stash-cli/package.json
+++ b/packages/stash-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cipherstash/stash-cli",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "CipherStash CLI",
   "types": "build/types/types.d.ts",
   "bin": {
@@ -30,9 +30,9 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
+    "@cipherstash/gluegun": "latest",
     "@cipherstash/stashjs": "workspace:*",
     "axios": "^0.27.2",
-    "@cipherstash/gluegun": "latest",
     "open": "^8.2.1",
     "yarn": "^1.22.11"
   },


### PR DESCRIPTION
Bumps `@cipherstash/stash-cli` to `0.5.2`
