### PR TITLE
fix: pnpm bin infer

### DIFF
--- a/packages/stash-cli/bin/stash
+++ b/packages/stash-cli/bin/stash
@@ -1,4 +1,6 @@
-#!/usr/bin/env -S node --stack-trace-limit=1024
+#!/usr/bin/env node
+
+Error.stackTraceLimit = 1024;
 
 /* tslint:disable */
 // check if we're running in dev mode
@@ -16,5 +18,3 @@ if (wantsCompiled || !devMode) {
   // run the CLI with the current process arguments
   require(`${__dirname}/../src/cli`).run(process.argv)
 }
-
-


### PR DESCRIPTION
There is an issue when running the cli with `pnpm`
```
$ pnpm exec stash list-collections
...snip.../node_modules/.bin/stash: line 16: exec: -S: invalid option
exec: usage: exec [-cl] [-a name] [command [argument ...]] [redirection ...]
```

This is because, `pnpm` wraps our cli with it's own shell script. In order to do this correctly, it needs to correctly infer the right command to use based on our `shebang` line.
Currently it's as follows:
```shell
#!/usr/bin/env -S node --stack-trace-limit=1024
```

The correct command to use here is `node`, but pnpm will infer this as `-S` which makes no sense!
If we move the stack trace limit arg from here into the file itself, this problem should be fixed.