### PR TITLE
Make path handling portable

### DIFF
--- a/packages/stash-cli/package.json
+++ b/packages/stash-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cipherstash/stash-cli",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "CipherStash CLI",
   "types": "build/types/types.d.ts",
   "bin": {


### PR DESCRIPTION
Previously we constructed unix-style paths by hand, as well as looked for the $HOME env var. This meant StashJS did not work on Windows (except when using WSL).

Now we use a portable mechanism to generate paths and discover the home directory of the user.