### PR TITLE
stash-cli fixes for CF blog post

### DIFF
--- a/packages/stash-cli/package.json
+++ b/packages/stash-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cipherstash/stash-cli",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "CipherStash CLI",
   "types": "build/types/types.d.ts",
   "bin": {

--- a/packages/stash-cli/src/commands/create-access-key.ts
+++ b/packages/stash-cli/src/commands/create-access-key.ts
@@ -8,14 +8,14 @@ const command: GluegunCommand = {
   name: "create-key",
 
   run: async (toolbox: Toolbox) => {
-    const { print, parameters } = toolbox
+    const { parameters } = toolbox
     const options = parameters.options
 
     function exitWithUsage(): never {
-      print.info("Usage: stash create-key --name <name for access key> [--profile <profile>] [--help]")
-      print.info("")
-      print.info("Creates an access key for the workspace\n")
-      print.info("")
+      console.log("Usage: stash create-key --name <name for access key> [--profile <profile>] [--pipe] [--help]")
+      console.log("")
+      console.log("Creates an access key for the workspace\n")
+      console.log("")
       process.exit(0)
     }
 
@@ -30,27 +30,27 @@ const command: GluegunCommand = {
     const keyName: string | undefined = parameters.options.name
 
     if (!keyName) {
-      print.error(`Expected an access key name`)
-      print.error(`Example: stash create-key --name keyName`)
+      console.error(`Expected an access key name`)
+      console.error(`Example: stash create-key --name keyName`)
       process.exit(1)
     }
 
-    print.info(`Generating access key ${keyName}.........`)
-    print.info("")
-    print.info("")
+    console.log(`Generating access key ${keyName}.........`)
+    console.log("")
+    console.log("")
 
     const profileName: string | undefined = parameters.options.profile
 
     const profile = await Stash.loadProfile({
       profileName,
     }).catch(error => {
-      print.error(`Unexpected error while loading profile. Reason: "${describeError(error)}"`)
+      console.error(`Unexpected error while loading profile. Reason: "${describeError(error)}"`)
       process.exit(1)
     })
 
     const connection = await StashInternal.connect(profile)
     if (!connection.ok) {
-      print.error(`Authentication failed - please try to login again with "stash login"`)
+      console.error(`Authentication failed - please try to login again with "stash login"`)
       process.exit(1)
     }
     const workspaceId = profile.config.service.workspace
@@ -58,8 +58,8 @@ const command: GluegunCommand = {
     const authInfo = await profile.withFreshDataServiceCredentials(async creds => Ok(creds)).freshValue()
 
     if (!authInfo.ok) {
-      print.error('An error occurred and "stash login" could not complete successfully')
-      print.error(`Reason: ${errors.toErrorMessage(authInfo.error)}`)
+      console.error('An error occurred and "stash login" could not complete successfully')
+      console.error(`Reason: ${errors.toErrorMessage(authInfo.error)}`)
       process.exit(1)
     }
 
@@ -74,7 +74,7 @@ const command: GluegunCommand = {
         }
       )
       .catch(error => {
-        print.error(
+        console.error(
           `Failed to create creds. API responded with code: '${error.response?.status}' and body: '${JSON.stringify(
             error.response.data
           )}'`
@@ -83,20 +83,20 @@ const command: GluegunCommand = {
       })
     const accessKey = response.data
 
-    print.info("Access Key created!")
-    print.info("")
-    print.info("")
-    print.info(`The key ${keyName} for workspace ${workspaceId} is:`)
-    print.info("")
-    print.info(`CS_IDP_CLIENT_SECRET=${accessKey}`)
-    print.info("")
-    print.info(
+    console.log("Access Key created!")
+    console.log("")
+    console.log("")
+    console.log(`The key ${keyName} for workspace ${workspaceId} is:`)
+    console.log("")
+    console.log(`CS_IDP_CLIENT_SECRET=${accessKey}`)
+    console.log("")
+    console.log(
       "For more details on how to use this key visit https://docs.cipherstash.com/reference/client-configuration.html "
     )
     // TODO: Update this link when docs are updated
-    print.info("")
-    print.info("")
-    print.info("")
+    console.log("")
+    console.log("")
+    console.log("")
   },
 }
 

--- a/packages/stash-cli/src/commands/export-schema.ts
+++ b/packages/stash-cli/src/commands/export-schema.ts
@@ -38,6 +38,7 @@ const command: GluegunCommand = {
         exitWithUsage("error")
       }
 
+
       const collection = await stash.loadCollection(collectionName)
       const indexes = {}
 
@@ -63,6 +64,7 @@ const command: GluegunCommand = {
         type: collection.schema.recordType,
         ref: [...Buffer.from(collection.ref, "hex")],
         indexes,
+        service: profile.config.service
       }
 
       // Console log instead of using `print.info` here so output can be redirected to a file.

--- a/packages/stash-cli/src/commands/export-schema.ts
+++ b/packages/stash-cli/src/commands/export-schema.ts
@@ -38,7 +38,6 @@ const command: GluegunCommand = {
         exitWithUsage("error")
       }
 
-
       const collection = await stash.loadCollection(collectionName)
       const indexes = {}
 
@@ -64,7 +63,7 @@ const command: GluegunCommand = {
         type: collection.schema.recordType,
         ref: [...Buffer.from(collection.ref, "hex")],
         indexes,
-        service: profile.config.service
+        service: profile.config.service,
       }
 
       // Console log instead of using `print.info` here so output can be redirected to a file.


### PR DESCRIPTION
A few misc changes to the stash-cli for the CF blogpost.

- Change to print with console.log to remove control chars
- Add service section to exported schema (to get host in CF worker)
- Bump stash-cli to 0.6.0 for publish