### PR TITLE
Dockerise the build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ tsconfig.tsbuildinfo
 # npm/pnpm logs
 .pnpm-debug.log
 npm-debug.log*
+.pnpm-store
 
 # test coverages
 coverage

--- a/.tool-versions
+++ b/.tool-versions
@@ -4,3 +4,4 @@ protoc 21.10
 rust nightly
 shellcheck 0.7.2
 shfmt 3.4.0
+postgres 14.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+# Build the container with:
+#
+#   docker build -t cipherstash-js .
+#
+# Start a bash shell in the container with:
+#
+#   docker run --mount src=$(pwd),target=/home/cipherstash/build,type=bind -it cipherstash-js bash
+#
+# From within you can:
+#
+#   cd build
+#   ./build.sh build # or test # etc
+
+# This will install a base image specific to the host architecture.
+FROM ubuntu:latest
+
+# This will force non-interactive apt package installs, choosing sensible
+# default options
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Add package source for NodeJS 14.X
+RUN apt update
+RUN apt -y install curl
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+
+RUN apt update
+RUN apt -y install git build-essential vim \
+    protobuf-compiler libreadline-dev zlib1g-dev libssl-dev \
+    uuid-dev unzip postgresql postgresql-contrib nodejs \
+    shellcheck shfmt libssl-dev pkg-config
+
+RUN sudo; \
+    useradd --create-home --shell /bin/bash cipherstash; \
+    /bin/bash -c 'echo "cipherstash:password" | chpasswd'; \
+    adduser cipherstash sudo
+
+USER cipherstash
+WORKDIR /home/cipherstash
+
+# Install Rust
+RUN curl --proto '=https' --tlsv1.3 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/home/cipherstash/.cargo/bin:${PATH}"
+RUN rustup default nightly
+
+# Make it so that "npm install -g foo" writes into a location where the
+# cipherstash user has write permissions
+RUN mkdir -p /home/cipherstash/.local/bin
+ENV PATH="${PATH}:/home/cipherstash/.local/bin"
+RUN npm config set prefix '/home/cipherstash/.local/'
+
+# Install pnpm
+ENV PNPM_HOME="/home/cipherstash/.local/share/pnpm"
+ENV PATH="${PATH}:${PNPM_HOME}"
+RUN npm install --global pnpm
+# When running pnpm in the docker container we need to ensure its store is
+# local to the container (and not shared with the store on the host).  This is
+# because the store uses hard links and hard links do not work across mounts.
+RUN pnpm config set store-dir /home/cipherstash/.pnpm-store

--- a/build.sh
+++ b/build.sh
@@ -14,21 +14,23 @@ fi
 trap "echo SOMETHING WENT WRONG - please read the logs above and see if it helps you figure out what is wrong - and also ask an engineer help" ERR
 
 setup() {
-  asdf plugin add postgres || true
-  asdf plugin add protoc || true
-  asdf plugin add rust || true
-  asdf plugin add nodejs || true
-  asdf plugin add pnpm || true
-  asdf plugin add shellcheck || true
-  asdf plugin add shfmt || true
+  if command -v asdf &> /dev/null; then
+    asdf plugin add postgres || true
+    asdf plugin add protoc || true
+    asdf plugin add rust || true
+    asdf plugin add nodejs || true
+    asdf plugin add pnpm || true
+    asdf plugin add shellcheck || true
+    asdf plugin add shfmt || true
 
-  asdf install
-  asdf reshim
+    asdf install
+    asdf reshim
+  fi
 
   # Install wasm for @cipherstash/stash-rs
+  cargo install wasm-pack
+  cargo install wasm-opt
   rustup target add wasm32-unknown-unknown
-
-  pnpm install --frozen-lockfile
 }
 
 build() {

--- a/packages/stash-rs/package.json
+++ b/packages/stash-rs/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "clean": "rm -rf ./pkg",
-    "build": "pnpm rebuild wasm-pack && rm -rf ./pkg && wasm-pack build . --target nodejs && tsc --build && ./fix-imports.sh",
+    "build": "rm -rf ./pkg && wasm-pack build . --target nodejs && tsc --build && ./fix-imports.sh",
     "prepublishOnly": "npm run build",
     "test": "cargo test && npx jest"
   },
@@ -52,8 +52,7 @@
     "@types/jest": "^27.0.3",
     "@types/node": "^17.0.4",
     "ts-node": "^10.9.1",
-    "typescript": "^4.7.4",
-    "wasm-pack": "^0.10.3"
+    "typescript": "^4.7.4"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,7 +62,6 @@ importers:
       cbor: ^8.1.0
       ts-node: ^10.9.1
       typescript: ^4.7.4
-      wasm-pack: ^0.10.3
     dependencies:
       cargo-cp-artifact: 0.1.6
       cbor: 8.1.0
@@ -74,7 +73,6 @@ importers:
       '@types/node': 17.0.45
       ts-node: 10.9.1_x2utdhayajzrh747hktprshhby
       typescript: 4.7.4
-      wasm-pack: 0.10.3
 
   packages/stash-typedoc:
     specifiers:
@@ -3759,6 +3757,7 @@ packages:
       follow-redirects: 1.15.1
     transitivePeerDependencies:
       - debug
+    dev: false
 
   /axios/0.27.2:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
@@ -3954,17 +3953,6 @@ packages:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
     dependencies:
       tweetnacl: 0.14.5
-    dev: true
-
-  /binary-install/0.1.1:
-    resolution: {integrity: sha512-DqED0D/6LrS+BHDkKn34vhRqOGjy5gTMgvYZsGK2TpNbdPuz4h+MRlNgGv5QBRd7pWq/jylM4eKNCizgAq3kNQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      axios: 0.21.4
-      rimraf: 3.0.2
-      tar: 6.1.11
-    transitivePeerDependencies:
-      - debug
     dev: true
 
   /bindings/1.5.0:
@@ -5487,6 +5475,7 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+    dev: false
 
   /for-each/0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -10333,16 +10322,6 @@ packages:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
     dependencies:
       makeerror: 1.0.12
-    dev: true
-
-  /wasm-pack/0.10.3:
-    resolution: {integrity: sha512-dg1PPyp+QwWrhfHsgG12K/y5xzwfaAoK1yuVC/DUAuQsDy5JywWDuA7Y/ionGwQz+JBZVw8jknaKBnaxaJfwTA==}
-    hasBin: true
-    requiresBuild: true
-    dependencies:
-      binary-install: 0.1.1
-    transitivePeerDependencies:
-      - debug
     dev: true
 
   /wcwidth/1.0.1:


### PR DESCRIPTION
Why did I do this?

1. Our builds had stopped working on a Mac because of use of `sed` in a build script - the Mac and Linux versions are different
2. asdf tool proliferation has become a thing across our projects
3. I can no longer get asdf postgres to install successfully on my mac

The base image (ubuntu:latest) will install a version appropriate to your host architecture - i.e. x86_64 or arm64 so nobody has to pay an unfair performance penalty.

It takes about 2 minutes to build the image. Once built, commands can be executed in the container with the host repo mounted inside of it. There does not appear to be any noticable performance drop in build times but I have not run benchmarks.